### PR TITLE
Added a prompt to select a action template type

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,13 +2,13 @@
     "templates": {
         "Roboto generic action": {
             "path": "./cookiecutter-roboto-generic-action",
-            "title": "Roboto generic action",
-            "description": "A Roboto action project"
+            "title": "Roboto Generic Action",
+            "description": "A Generic Roboto Action Package"
         },
         "Roboto python action": {
             "path": "./cookiecutter-roboto-python-action",
-            "title": "Roboto python action",
-            "description": "A Roboto action python package"
+            "title": "Roboto Python Action",
+            "description": "A Roboto Action Python Package"
         }
     }
 }


### PR DESCRIPTION
# What's changed?
Added a prompt to select a action template type so you can invoke cookiecutter on the root of this project

# How has this been tested?
Ran it locally

<img width="755" alt="Screenshot 2024-02-01 at 3 51 55 PM" src="https://github.com/roboto-ai/cookiecutter-roboto-actions/assets/157407529/4d6ae57e-a5ff-4f31-a799-4f9ebe1fa655">
