### PR TITLE
Use 'python3' as Python executable in setup.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.swp
 *.pyc
 output
+.idea/

--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@ cookiecutter-roboto-actions
 ===========================
 
 Project templates for initializing Roboto Actions.
+
+### Development
+* `make install` to build the project locally
+* `make fmt && make lint` before pushing a commit
+
+### Testing
+Run: `.venv/bin/cookiecutter --output-dir <some-temp-dir> .`
+
+This will walk you through the workflow of creating a new action, same as `roboto actions init`.

--- a/cookiecutter-roboto-generic-action/{{cookiecutter.__project_slug}}/scripts/setup.sh
+++ b/cookiecutter-roboto-generic-action/{{cookiecutter.__project_slug}}/scripts/setup.sh
@@ -8,7 +8,7 @@ PACKAGE_ROOT=$(dirname "${SCRIPTS_ROOT}")
 venv_dir="$PACKAGE_ROOT/.venv"
 
 # Create a virtual environment
-python -m venv --upgrade-deps $venv_dir
+python3 -m venv --upgrade-deps $venv_dir
 
 # Install roboto
 pip_exe="$venv_dir/bin/pip"

--- a/cookiecutter-roboto-python-action/{{cookiecutter.__project_slug}}/scripts/setup.sh
+++ b/cookiecutter-roboto-python-action/{{cookiecutter.__project_slug}}/scripts/setup.sh
@@ -8,7 +8,7 @@ PACKAGE_ROOT=$(dirname "${SCRIPTS_ROOT}")
 venv_dir="$PACKAGE_ROOT/.venv"
 
 # Create a virtual environment
-python -m venv --clear --upgrade-deps $venv_dir
+python3 -m venv --clear --upgrade-deps $venv_dir
 
 # Install dev deps
 pip_exe="$venv_dir/bin/pip"


### PR DESCRIPTION
Overview
--------
Customers have reported that they can't run the `setup.sh` script of a freshly-created Roboto action, because it runs Python as `python`, which they have to change to `python3`.

Reading PEP-394, it seems that as long as Python 3 is installed, the `python3` command will be available. Reading StackOverflow, it seems like some Linux distros will only ship with `python3` as a viable command, with extra options for people who want to symlink `python` to `python3`.

For these reasons, I feel it's safe enough to change our default to `python3`.

Bonus
-------
Some README instructions on how to develop in this repo.

Testing
--------
* `make install && make fmt && make lint` &rarr; OK
* `.venv/bin/cookiecutter --output-dir /tmp/demo_action .` &rarr; created demo Python action and deployed it to my dev account. Action was invocable and did what the demo code does.
* Updated setup.sh for my custom action I'd previously created with `roboto actions init`. Re-build and re-deployment worked OK, and the action ran as expected.